### PR TITLE
loosening the workerman version constraint from 3.3.* to 3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "http://www.workerman.net",
     "license" : "MIT",
     "require": {
-        "workerman/workerman" : "~3.3.0",
+        "workerman/workerman" : "~3.3",
         "workerman/channel": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION

loosening the workerman version constraint from 3.3.* to 3.*  
tested with the latest version and it still works fine so seems a good change